### PR TITLE
Rename module. Closes #5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = bed tetris
+name = bed allocation
 description = Optimization for Bed Allocation within hospitals
 author = Faculty
 author-email = info@faculty.ai
@@ -50,7 +50,7 @@ linting =
 [tool:pytest]
 # Options for py.test:
 addopts =
-    --cov bed-tetris --cov-report term-missing
+    --cov bed-allocation --cov-report term-missing
     --verbose
 norecursedirs =
     dist


### PR DESCRIPTION
# Summary

**What/Why**

Renames the module to `bed allocation`, deprecating `bed tetris`.

**What to review**

1. To install the module and tests run `pip install -e ."[testing]"`
2. To run the tests run `pytest`

I can confirm this works as per screenshot:

![Screenshot 2021-11-23 at 11 20 15](https://user-images.githubusercontent.com/534681/143015609-61846eff-3956-4136-a84d-c0d9cb1cee80.png)

Note the same warning is generated for code prior to changes.

# Checklists

<!--
These are DO-CONFIRM checklists; it CONFIRMs that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are
irrelevant, please try and add a comment stating why.

Incomplete pull/merge requests MAY be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [X] code runs
- [x] [developments are ethical][data-ethics-framework]
- [X] developments are secure (no data or notebook output)
- [X] you have made proportionate checks that the code works correctly
- [X] [minimum usable documentation][agilemodeling] written in the `docs` folder

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework

